### PR TITLE
fix(graphql): ensure that operations is the first part of the request

### DIFF
--- a/multipart.go
+++ b/multipart.go
@@ -17,13 +17,11 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 		return err
 	}
 
-	params := map[string]string{
-		"operations": string(operations),
-		"map":        req.FileMap(),
-	}
-
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
+
+	_ = writer.WriteField("operations", string(operations))
+	_ = writer.WriteField("map", req.FileMap())
 
 	for i, file := range req.files {
 		key := fmt.Sprintf("%d", i+1)
@@ -36,10 +34,6 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 		if _, err := io.Copy(part, file.R); err != nil {
 			return errors.Wrap(err, "preparing file")
 		}
-	}
-
-	for key, val := range params {
-		_ = writer.WriteField(key, val)
 	}
 
 	err = writer.Close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure that operations is the first part parsed by the server.

## Motivation and Context
A bug when uploading files with this client was found because operations field must be the first part of the form.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
